### PR TITLE
fsinfo: Load all documents without data

### DIFF
--- a/app/gws/ext/action/fsinfo/__init__.py
+++ b/app/gws/ext/action/fsinfo/__init__.py
@@ -410,9 +410,12 @@ class Object(gws.common.action.Object):
         with self.db.connect() as conn:
             rs = conn.select(f'''
                 SELECT
-                    *,
                     {self.document_table.key_column} as uid,
-                    '' AS data
+                    pn,
+                    title,
+                    size,
+                    filename,
+                    created
                 FROM
                     {self.document_table.name}
                 WHERE


### PR DESCRIPTION
The query was likely intended to not load column data by specifying

    SELECT
      *,
      '' AS data

This will, however, not override column "data" which is already selected by specifying the SELECT list with a wildcard.